### PR TITLE
Split CI into multiple jobs to make it faster and clearer

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust project CI
+name: Digital Voting CI
 
 # TODO probably a good idea to specify specific toolchain versions in the future.
 
@@ -16,7 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Prioritizing speed over size here.
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -40,7 +39,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Prioritizing speed over size here.
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -62,7 +60,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Prioritizing speed over size here.
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -83,7 +80,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Prioritizing speed over size here.
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
@@ -106,12 +102,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    # Prioritizing speed over size here.
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         profile: default
-        toolchain: stable
+        toolchain: nightly
         override: true
 
     - name: Install cargo-deny
@@ -130,4 +125,4 @@ jobs:
         version: latest
 
     - name: Check unused dependencies with cargo-udeps
-      run: cargo udeps --all-targets
+      run: cargo +nightly udeps --all-targets

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,7 @@
 name: Rust project CI
 
+# TODO probably a good idea to specify specific toolchain versions in the future.
+
 on:
   push:
     branches: [ main ]
@@ -7,8 +9,8 @@ on:
     types: [opened, synchronize]
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  build:
+    name: Build (only check for now)
     runs-on: ubuntu-latest
 
     steps:
@@ -19,14 +21,32 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: default
-        toolchain: nightly
+        toolchain: stable
         override: true
 
+    # Not storing the artifacts yet, because the application is too bare bones for now.
+    # And since we're not storing artifacts, we can just check instead of build.
     - name: Build
       uses: actions-rs/cargo@v1
       with:
-        command: build
+        command: check
         args: --verbose
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Prioritizing speed over size here.
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
 
     - name: Run tests
       uses: actions-rs/cargo@v1
@@ -34,17 +54,65 @@ jobs:
         command: test
         args: --verbose
 
+  formatting:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Prioritizing speed over size here.
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
+  
     - name: Check formatting
       uses: actions-rs/cargo@v1
       with:
         command: fmt
         args: -- --check
+  lint:
+    name: Run linters
+    runs-on: ubuntu-latest
+    needs: build
 
+    steps:
+    - uses: actions/checkout@v2
+
+    # Prioritizing speed over size here.
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
+      
+      
     - name: Lint with Clippy
       uses: actions-rs/cargo@v1
       with:
         command: clippy
         args: -- -D warnings
+
+  dependencies:
+    name: Check dependencies
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Prioritizing speed over size here.
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: default
+        toolchain: stable
+        override: true
 
     - name: Install cargo-deny
       uses: actions-rs/install@v0.1


### PR DESCRIPTION
CI also won't continue to run if build fails
Besides that changed build to only check for now since we're not storing artifacts yet anyway