### PR TITLE
Add Poseidon hasher

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,6 +115,7 @@ jobs:
         command: clippy
         args: -- -D warnings
 
+  # TODO This job is taking way too long compared to the rest.
   dependencies:
     name: Check dependencies
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arrayref"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +312,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake2b_simd"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +369,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -380,6 +421,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
@@ -432,10 +479,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
@@ -488,6 +560,9 @@ dependencies = [
  "base64",
  "bincode",
  "chrono",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "merkle_light",
  "rand",
  "ring",
  "serde",
@@ -499,6 +574,12 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -514,6 +595,17 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "flate2"
@@ -539,6 +631,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -598,6 +696,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +726,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "halo2_gadgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "ff",
+ "group",
+ "halo2_proofs",
+ "lazy_static",
+ "pasta_curves",
+ "rand",
+ "subtle",
+ "uint",
+]
+
+[[package]]
+name = "halo2_proofs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "maybe-rayon",
+ "pasta_curves",
+ "rand_core",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +769,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -729,6 +877,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -770,10 +921,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "merkle_light"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b879f617ec392ad9c11a50356ca373009c52363c0953b34c2e1b2234037a26a9"
 
 [[package]]
 name = "mime"
@@ -890,6 +1057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pasta_curves"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "lazy_static",
+ "rand",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,6 +1185,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1195,6 +1403,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,6 +1424,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -1411,6 +1637,18 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1700,6 +1938,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,6 @@ dependencies = [
  "chrono",
  "halo2_gadgets",
  "halo2_proofs",
- "merkle_light",
  "rand",
  "ring",
  "serde",
@@ -935,12 +934,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "merkle_light"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b879f617ec392ad9c11a50356ca373009c52363c0953b34c2e1b2234037a26a9"
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 tracing-appender = "0.2.3"
 tracing-actix-web = "0.7.11"
+# TODO keep in mind that halo2 paralellism may be an issue with Tokio
+halo2_proofs = "0.3.0"
+halo2_gadgets = "0.3.0"
+merkle_light = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,3 @@ tracing-actix-web = "0.7.11"
 # TODO keep in mind that halo2 paralellism may be an issue with Tokio
 halo2_proofs = "0.3.0"
 halo2_gadgets = "0.3.0"
-merkle_light = "0.4.0"

--- a/deny.toml
+++ b/deny.toml
@@ -96,6 +96,7 @@ allow = [
     "OpenSSL",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
+    "BSD-2-Clause",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod api;
 
 pub mod batcher;
 pub mod set_membership;
+mod utils;
 
 mod chain;
 use chain::blockchain::{BlockValue, Blockchain, Error as BlockchainError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 pub mod api;
 
 pub mod batcher;
+pub mod set_membership;
 
 mod chain;
 use chain::blockchain::{BlockValue, Blockchain, Error as BlockchainError};

--- a/src/set_membership/mod.rs
+++ b/src/set_membership/mod.rs
@@ -1,0 +1,5 @@
+// pub mod zkp;
+
+// TODO doctests are forcing me to make some mods pub, so need to investigate how to keep them private.
+// mod poseidon_chip;
+pub mod poseidon_hasher;

--- a/src/set_membership/poseidon_hasher.rs
+++ b/src/set_membership/poseidon_hasher.rs
@@ -1,19 +1,19 @@
-//! Module containing the Poseidon hasher and it's trait implementations required for it to work with the Merkle tree
-//! from the merkle_light crate. Also providing a standalone Poseidon hash function for convenience.
+//! Module containing a more user friendly version of the the Poseidon hash function from the halo2_gadgets crate
+//! And the Digest type for more convenient interoperability with other types.
 //!
-//! Note that reusing the Poseidon hasher from the Halo2 crate turned to be pretty hacky, so will probably have to
-//! be reworked in the future, but will remain for now.
-//!
-//! Besides that merkle_light also proved to be quite messy and doing a custom merkle tree might be nice in the future.
+//! Note that reusing the Poseidon hasher from the Halo2 crate turned to be pretty hacky, due to halo2's types being
+//! hard to convert to other types.
 
+use crate::utils::byte_ops::convert_u8_to_u64;
 use halo2_gadgets::poseidon::primitives::{self as poseidon, ConstantLength, P128Pow5T3};
 use halo2_proofs::pasta::Fp;
-use merkle_light::hash::Algorithm;
-use std::hash::Hasher;
 
+// TODO After trying multiple different approaches (array, uin256 crates, etc), couldn't figure a way to
+// avoid having to create a new type for the hash value, since all existing types would be very unwieldy to use
+// so will have to try to figure this out some more in the future, but commiting this struct for now.
 /// Struct to abstract the hash value to be more interoperable with other types.
 /// The length of the hash is fixed to 32 bytes, because Poseidon hash operates on fields.
-/// The inner calue can be accessed directly since it's public.
+/// The inner value can be accessed directly since it's public.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq)]
 pub struct Digest(pub [u8; 32]);
 
@@ -54,174 +54,63 @@ impl From<[u8; 32]> for Digest {
     }
 }
 
-impl InternalHash for Digest {}
-
-// TODO there's probably a better place for this:
-fn convert_u8_to_u64(input: [u8; 32]) -> [u64; 4] {
-    let mut output = [0u64; 4];
-
-    for (i, item) in output.iter_mut().enumerate() {
-        let start = i * 8;
-        let end = start + 8;
-        *item = u64::from_le_bytes(input[start..end].try_into().unwrap());
-    }
-
-    output
-}
-
-/// Struct containing the hasher state to be used to plug the Poseidon hasher provided
-/// by the Halo2 crate into the Merkle tree provided by the merkle_light crate.
-#[derive(Debug, Default, PartialEq)]
-pub struct PoseidonHasher {
-    /// Counter for how many entries have been written to the hasher's input.
-    /// Used to prevent writing more than 2 entries.
-    /// In the future might be used to handle leaf nodes, when count is 1.
-    input_entry_count: usize,
-    /// The actual data to be hashed abstracted with the Digest struct for simpler
-    /// interoperability with other types. An array is used to avoid heap allocation.
-    input: [Digest; 2],
-}
-
-impl PoseidonHasher {
-    // TODO it'd probablt be nice to have a more ergonomic input, since rust can be annoying about arrays.
-    /// Hashes the input using the Poseidon hash function provided by Halo2 crate.
-    /// The main intention for this function is to hash the input data for the
-    /// Merkle tree leaf nodes.
-    ///
-    /// # Note
-    ///
-    /// Because Poseidon hash needs two inputs, using a copy of the single input of this
-    /// function as padding for the empty second input of the hash algorithm.
-    ///
-    /// # Arguments
-    ///
-    /// * `input` - The input data to be hashed as bytes. The length of the input is fixed to 32 bytes,
-    ///             because Poseidon hash operates on fields instead of regular numbers.
-    ///
-    /// # Returns
-    ///
-    /// * `digest` - The hash of the input data abstracted in a Digest type.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use digital_voting::set_membership::poseidon_hasher::PoseidonHasher;
-    ///
-    /// let input = [1u8; 32];
-    ///
-    /// let digest = PoseidonHasher::hash(input);
-    /// ```
-    pub fn hash(input: [u8; 32]) -> Digest {
-        let input = Fp::from_raw(convert_u8_to_u64(input));
-        let digest =
-            poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init().hash([input, input]);
-        digest.into()
+impl From<u64> for Digest {
+    fn from(value: u64) -> Self {
+        let mut buf = [0u8; 32];
+        buf[..8].copy_from_slice(&value.to_le_bytes());
+        Digest(buf)
     }
 }
 
-/// This trait is needed by the `Algorithm` trait so this hasher can be used with merkle_light crate.
-impl Hasher for PoseidonHasher {
-    fn finish(&self) -> u64 {
-        // merkle_light does not require this method.
-        unimplemented!()
-    }
-
-    fn write(&mut self, bytes: &[u8]) {
-        if self.input_entry_count >= 2 {
-            // TODO trace
-            return;
-        }
-        if bytes.len() > 32 {
-            // TODO trace
-            return;
-        }
-        // expect is fine here, since it's handled by the if statement above.
-        let input: Digest = bytes
-            .try_into()
-            .expect("Invalid Poseidon hasher input length");
-        self.input[self.input_entry_count] = input;
-        self.input_entry_count += 1;
+impl From<&u64> for Digest {
+    fn from(value: &u64) -> Self {
+        let mut buf = [0u8; 32];
+        buf[..8].copy_from_slice(&value.to_le_bytes());
+        Digest(buf)
     }
 }
 
-trait InternalHash: AsRef<[u8]> + Clone + Copy + From<[u8; 32]> {}
-
-// TODO this turned out to be a lot more hacky than I initially wanted:
-/// This is the trait that merkle_light uses to plug in external hasher implementations.
-impl<T: InternalHash> Algorithm<T> for PoseidonHasher {
-    /// Returns the Poseidon hash value for the expected two data inputs.
-    /// Called by merkle_light crate.
-    ///
-    /// # Returns
-    ///
-    /// * `digest` - The hash of the two inputs abstracted by Digest type.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the input count is not 1 or 2, since Poseidon hash requires two inputs.
-    fn hash(&mut self) -> T {
-        let input: [Fp; 2] = match self.input_entry_count {
-            // Padding Poseidon hash input with the same element since it needs two elements:
-            1 => [self.input[0].into(), self.input[0].into()],
-            2 => [self.input[0].into(), self.input[1].into()],
-            // Should never happen:
-            _ => panic!("Invalid Poseidon hasher input count"),
-        };
-        // TODO Poseidon configuration should be passed as a parameter or at least be a constant:
-        let digest = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init().hash(input);
-        let digest_bytes: [u8; 32] = digest.into();
-        T::from(digest_bytes)
-    }
-
-    /// Reset Hasher state.
-    #[inline]
-    fn reset(&mut self) {
-        *self = Self::default();
-    }
-
-    /// No need for extra operations to be done on an already hashed leaf.
-    ///
-    /// # Note
-    ///
-    /// merkle_light's documentation is really lacking and this method is actually called
-    /// on leaves that are already hashed by the method in the `Hasher` trait.
-    ///
-    /// # Arguments
-    ///
-    /// * `leaf` - A leaf of the Merkle tree. This method is used for actions on the already hashed leaf,
-    ///            but nothing is needed for this implementation.
-    ///
-    /// # Returns
-    ///
-    /// * `leaf` - The same leaf that was passed as an argument.
-    #[inline]
-    fn leaf(&mut self, leaf: T) -> T {
-        leaf
-    }
-
-    /// Returns the hash value for two neighboring nodes in the Merkle tree.
-    ///
-    /// # Arguments
-    ///
-    /// * `left` - The left node (hash) of the Merkle tree.
-    /// * `right` - The right node (hash) of the Merkle tree.
-    ///
-    /// # Returns
-    ///
-    /// * `hash` - The hash of the two neighboring nodes.
-    #[inline]
-    fn node(&mut self, left: T, right: T) -> T {
-        self.write(left.as_ref());
-        self.write(right.as_ref());
-        self.hash()
-    }
+/// Hashes the input using the Poseidon hash function provided by Halo2 crate.
+/// The main intention for this function is to hash the input data for the
+/// Merkle tree leaf nodes.
+///
+/// # Note
+///
+/// Because Poseidon hash needs two inputs, using a copy of the single input of this
+/// function as padding for the empty second input of the hash algorithm.
+///
+/// # Arguments
+///
+/// * `input` - The input data to be hashed as bytes. The length of the input is fixed to 32 bytes,
+///             because Poseidon hash operates on fields instead of regular numbers.
+///
+/// # Returns
+///
+/// * `digest` - The hash of the input data abstracted in a Digest type.
+///
+/// # Example
+///
+/// ```
+/// use digital_voting::set_membership::poseidon_hasher;
+/// use digital_voting::set_membership::poseidon_hasher::Digest;
+///
+/// let input = [Digest([1u8; 32]), Digest([2u8; 32])];
+///
+/// let digest = poseidon_hasher::hash(input);
+/// ```
+pub fn hash(input: [Digest; 2]) -> Digest {
+    let input = [
+        Fp::from_raw(convert_u8_to_u64(input[0].0)),
+        Fp::from_raw(convert_u8_to_u64(input[1].0)),
+    ];
+    let digest =
+        poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init().hash([input[0], input[1]]);
+    digest.into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use merkle_light::merkle::MerkleTree;
 
     // TODO, need to find out test values and make sure there aren't any bugs in the poseidon hash or the implementation around it.
     #[ignore]
@@ -238,36 +127,5 @@ mod tests {
             .hash(input)
             .into();
         assert_eq!(expected_result, digest);
-    }
-
-    // Checking if merkle tree handles the data (and the underlying bytes, endiness, etc) as expected.
-    #[test]
-    fn test_merkle_tree() {
-        let elements = vec![1u64, 2u64, 3u64];
-        let hash_iter = elements.iter().map(|x| {
-            PoseidonHasher::hash({
-                let mut array = [0u8; 32];
-                array[..8].copy_from_slice(&x.to_le_bytes());
-                array
-            })
-        });
-        let tree = MerkleTree::<Digest, PoseidonHasher>::from_iter(hash_iter);
-        let root = tree.root();
-
-        let digest1 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
-            .hash([Fp::from(1u64), Fp::from(1u64)]);
-        let digest2 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
-            .hash([Fp::from(2u64), Fp::from(2u64)]);
-        let digest3 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
-            .hash([Fp::from(3u64), Fp::from(3u64)]);
-        let digest12 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
-            .hash([digest1, digest2]);
-        let digest33 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
-            .hash([digest3, digest3]);
-        let digest123: Digest = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
-            .hash([digest12, digest33])
-            .into();
-
-        assert_eq!(root, digest123);
     }
 }

--- a/src/set_membership/poseidon_hasher.rs
+++ b/src/set_membership/poseidon_hasher.rs
@@ -1,0 +1,273 @@
+//! Module containing the Poseidon hasher and it's trait implementations required for it to work with the Merkle tree
+//! from the merkle_light crate. Also providing a standalone Poseidon hash function for convenience.
+//!
+//! Note that reusing the Poseidon hasher from the Halo2 crate turned to be pretty hacky, so will probably have to
+//! be reworked in the future, but will remain for now.
+//!
+//! Besides that merkle_light also proved to be quite messy and doing a custom merkle tree might be nice in the future.
+
+use halo2_gadgets::poseidon::primitives::{self as poseidon, ConstantLength, P128Pow5T3};
+use halo2_proofs::pasta::Fp;
+use merkle_light::hash::Algorithm;
+use std::hash::Hasher;
+
+/// Struct to abstract the hash value to be more interoperable with other types.
+/// The length of the hash is fixed to 32 bytes, because Poseidon hash operates on fields.
+/// The inner calue can be accessed directly since it's public.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Ord, PartialOrd, Eq)]
+pub struct Digest(pub [u8; 32]);
+
+impl TryFrom<&[u8]> for Digest {
+    type Error = &'static str;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() > 32 {
+            return Err("Invalid input length");
+        }
+        let mut internal = Self::default();
+        internal.0.copy_from_slice(value);
+        Ok(internal)
+    }
+}
+
+impl From<Fp> for Digest {
+    fn from(fp: Fp) -> Self {
+        Digest(fp.into())
+    }
+}
+
+impl From<Digest> for Fp {
+    fn from(val: Digest) -> Fp {
+        Fp::from_raw(convert_u8_to_u64(val.0))
+    }
+}
+
+impl AsRef<[u8]> for Digest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for Digest {
+    fn from(value: [u8; 32]) -> Self {
+        Digest(value)
+    }
+}
+
+impl InternalHash for Digest {}
+
+// TODO there's probably a better place for this:
+fn convert_u8_to_u64(input: [u8; 32]) -> [u64; 4] {
+    let mut output = [0u64; 4];
+
+    for (i, item) in output.iter_mut().enumerate() {
+        let start = i * 8;
+        let end = start + 8;
+        *item = u64::from_le_bytes(input[start..end].try_into().unwrap());
+    }
+
+    output
+}
+
+/// Struct containing the hasher state to be used to plug the Poseidon hasher provided
+/// by the Halo2 crate into the Merkle tree provided by the merkle_light crate.
+#[derive(Debug, Default, PartialEq)]
+pub struct PoseidonHasher {
+    /// Counter for how many entries have been written to the hasher's input.
+    /// Used to prevent writing more than 2 entries.
+    /// In the future might be used to handle leaf nodes, when count is 1.
+    input_entry_count: usize,
+    /// The actual data to be hashed abstracted with the Digest struct for simpler
+    /// interoperability with other types. An array is used to avoid heap allocation.
+    input: [Digest; 2],
+}
+
+impl PoseidonHasher {
+    // TODO it'd probablt be nice to have a more ergonomic input, since rust can be annoying about arrays.
+    /// Hashes the input using the Poseidon hash function provided by Halo2 crate.
+    /// The main intention for this function is to hash the input data for the
+    /// Merkle tree leaf nodes.
+    ///
+    /// # Note
+    ///
+    /// Because Poseidon hash needs two inputs, using a copy of the single input of this
+    /// function as padding for the empty second input of the hash algorithm.
+    ///
+    /// # Arguments
+    ///
+    /// * `input` - The input data to be hashed as bytes. The length of the input is fixed to 32 bytes,
+    ///             because Poseidon hash operates on fields instead of regular numbers.
+    ///
+    /// # Returns
+    ///
+    /// * `digest` - The hash of the input data abstracted in a Digest type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use digital_voting::set_membership::poseidon_hasher::PoseidonHasher;
+    ///
+    /// let input = [1u8; 32];
+    ///
+    /// let digest = PoseidonHasher::hash(input);
+    /// ```
+    pub fn hash(input: [u8; 32]) -> Digest {
+        let input = Fp::from_raw(convert_u8_to_u64(input));
+        let digest =
+            poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init().hash([input, input]);
+        digest.into()
+    }
+}
+
+/// This trait is needed by the `Algorithm` trait so this hasher can be used with merkle_light crate.
+impl Hasher for PoseidonHasher {
+    fn finish(&self) -> u64 {
+        // merkle_light does not require this method.
+        unimplemented!()
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        if self.input_entry_count >= 2 {
+            // TODO trace
+            return;
+        }
+        if bytes.len() > 32 {
+            // TODO trace
+            return;
+        }
+        // expect is fine here, since it's handled by the if statement above.
+        let input: Digest = bytes
+            .try_into()
+            .expect("Invalid Poseidon hasher input length");
+        self.input[self.input_entry_count] = input;
+        self.input_entry_count += 1;
+    }
+}
+
+trait InternalHash: AsRef<[u8]> + Clone + Copy + From<[u8; 32]> {}
+
+// TODO this turned out to be a lot more hacky than I initially wanted:
+/// This is the trait that merkle_light uses to plug in external hasher implementations.
+impl<T: InternalHash> Algorithm<T> for PoseidonHasher {
+    /// Returns the Poseidon hash value for the expected two data inputs.
+    /// Called by merkle_light crate.
+    ///
+    /// # Returns
+    ///
+    /// * `digest` - The hash of the two inputs abstracted by Digest type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the input count is not 1 or 2, since Poseidon hash requires two inputs.
+    fn hash(&mut self) -> T {
+        let input: [Fp; 2] = match self.input_entry_count {
+            // Padding Poseidon hash input with the same element since it needs two elements:
+            1 => [self.input[0].into(), self.input[0].into()],
+            2 => [self.input[0].into(), self.input[1].into()],
+            // Should never happen:
+            _ => panic!("Invalid Poseidon hasher input count"),
+        };
+        // TODO Poseidon configuration should be passed as a parameter or at least be a constant:
+        let digest = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init().hash(input);
+        let digest_bytes: [u8; 32] = digest.into();
+        T::from(digest_bytes)
+    }
+
+    /// Reset Hasher state.
+    #[inline]
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    /// No need for extra operations to be done on an already hashed leaf.
+    ///
+    /// # Note
+    ///
+    /// merkle_light's documentation is really lacking and this method is actually called
+    /// on leaves that are already hashed by the method in the `Hasher` trait.
+    ///
+    /// # Arguments
+    ///
+    /// * `leaf` - A leaf of the Merkle tree. This method is used for actions on the already hashed leaf,
+    ///            but nothing is needed for this implementation.
+    ///
+    /// # Returns
+    ///
+    /// * `leaf` - The same leaf that was passed as an argument.
+    #[inline]
+    fn leaf(&mut self, leaf: T) -> T {
+        leaf
+    }
+
+    /// Returns the hash value for two neighboring nodes in the Merkle tree.
+    ///
+    /// # Arguments
+    ///
+    /// * `left` - The left node (hash) of the Merkle tree.
+    /// * `right` - The right node (hash) of the Merkle tree.
+    ///
+    /// # Returns
+    ///
+    /// * `hash` - The hash of the two neighboring nodes.
+    #[inline]
+    fn node(&mut self, left: T, right: T) -> T {
+        self.write(left.as_ref());
+        self.write(right.as_ref());
+        self.hash()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use merkle_light::merkle::MerkleTree;
+
+    // TODO, need to find out test values and make sure there aren't any bugs in the poseidon hash or the implementation around it.
+    #[ignore]
+    #[test]
+    fn test_poseidon_hasher_test_values() {
+        // TODO currently these values are wrong, need to find the correct ones.
+        let input = [Fp::from(1234567890), Fp::from(1234567890)];
+        let expected_result: [u8; 32] = [
+            0x15, 0x09, 0x82, 0x90, 0x1a, 0xd0, 0x84, 0x45, 0xad, 0x2d, 0x8f, 0x63, 0xed, 0x38,
+            0xa0, 0x98, 0xb5, 0xd1, 0x88, 0x4b, 0x52, 0x6e, 0x0d, 0xf7, 0x73, 0x95, 0xdf, 0xa0,
+            0x3d, 0xc8, 0x19, 0x93,
+        ];
+        let digest: [u8; 32] = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash(input)
+            .into();
+        assert_eq!(expected_result, digest);
+    }
+
+    // Checking if merkle tree handles the data (and the underlying bytes, endiness, etc) as expected.
+    #[test]
+    fn test_merkle_tree() {
+        let elements = vec![1u64, 2u64, 3u64];
+        let hash_iter = elements.iter().map(|x| {
+            PoseidonHasher::hash({
+                let mut array = [0u8; 32];
+                array[..8].copy_from_slice(&x.to_le_bytes());
+                array
+            })
+        });
+        let tree = MerkleTree::<Digest, PoseidonHasher>::from_iter(hash_iter);
+        let root = tree.root();
+
+        let digest1 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash([Fp::from(1u64), Fp::from(1u64)]);
+        let digest2 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash([Fp::from(2u64), Fp::from(2u64)]);
+        let digest3 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash([Fp::from(3u64), Fp::from(3u64)]);
+        let digest12 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash([digest1, digest2]);
+        let digest33 = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash([digest3, digest3]);
+        let digest123: Digest = poseidon::Hash::<_, P128Pow5T3, ConstantLength<2>, 3, 2>::init()
+            .hash([digest12, digest33])
+            .into();
+
+        assert_eq!(root, digest123);
+    }
+}

--- a/src/utils/byte_ops.rs
+++ b/src/utils/byte_ops.rs
@@ -1,0 +1,27 @@
+//! This is a file for utility code regarding byte operations.
+
+/// Convert a [u8; 32] array to a [u32; 8] array.
+pub fn _convert_u8_to_u32(input: [u8; 32]) -> [u32; 8] {
+    let mut output = [0u32; 8];
+
+    for (i, item) in output.iter_mut().enumerate() {
+        let start = i * 4;
+        let end = start + 4;
+        *item = u32::from_le_bytes(input[start..end].try_into().unwrap());
+    }
+
+    output
+}
+
+/// Convert a [u8; 32] array to a [u64; 4] array.
+pub fn convert_u8_to_u64(input: [u8; 32]) -> [u64; 4] {
+    let mut output = [0u64; 4];
+
+    for (i, item) in output.iter_mut().enumerate() {
+        let start = i * 8;
+        let end = start + 8;
+        *item = u64::from_le_bytes(input[start..end].try_into().unwrap());
+    }
+
+    output
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,3 @@
+//! This module contains utility code used throughout the project.
+
+pub mod byte_ops;


### PR DESCRIPTION
Added one of the components required for the zkp used to verify that the voter's ID number is part of the actual registered voter ID set.

This hasher will be used to create the merkle tree for the registered voter ID set.

The implementation is far from perfect, but it will have to do for now to uphold the core structure of the project.