### PR TITLE
Add set membership verifying key serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,8 +727,7 @@ dependencies = [
 [[package]]
 name = "halo2_gadgets"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126a150072b0c38c7b573fe3eaf0af944a7fed09e154071bf2436d3f016f7230"
+source = "git+https://github.com/ThrasherLT/halo2.git?branch=ThrasherLT/VerifyingKey-serialization#cbb5c89d3194fee667f9017326b46f90aea42505"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -745,8 +744,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b867a8d9bbb85fca76fff60652b5cd19b853a1c4d0665cb89bee68b18d2caf0"
+source = "git+https://github.com/ThrasherLT/halo2.git?branch=ThrasherLT/VerifyingKey-serialization#cbb5c89d3194fee667f9017326b46f90aea42505"
 dependencies = [
  "blake2b_simd",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,5 @@ tracing-subscriber = "0.3.18"
 tracing-appender = "0.2.3"
 tracing-actix-web = "0.7.11"
 # TODO keep in mind that halo2 paralellism may be an issue with Tokio
-halo2_proofs = "0.3.0"
-halo2_gadgets = "0.3.0"
+halo2_proofs = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization" }
+halo2_gadgets = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization" }

--- a/src/set_membership_zkp/set_membership.rs
+++ b/src/set_membership_zkp/set_membership.rs
@@ -1,12 +1,14 @@
 //! Set membership zero-knowledge proof implementation for u64 type.
-
-// TODO proof needs to be serializable.
-// TODO needs rigorous testing before actual use.
+//! Keep in mind that this ZKP only proves set membership and does not prevent sending
+//! the same value twice or sending he wrong value.
+//!
+//! TODO: Needs rigorous testing before actual use.
 
 use super::merkle::{self, MerkleProof, MerkleTree};
 use super::set_membership_circuit::SetMembershipCircuit;
 
 use rand::rngs::OsRng;
+use serde::{Deserialize, Serialize};
 
 use crate::utils::byte_ops::convert_u8_to_u64;
 use halo2_proofs::circuit::Value;
@@ -17,6 +19,7 @@ use halo2_proofs::plonk::{
 use halo2_proofs::poly::commitment::Params;
 use halo2_proofs::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
 use thiserror::Error;
+use tracing::debug;
 
 /// Error type for Merkle Tree operations.
 #[derive(Error, Debug)]
@@ -33,16 +36,108 @@ pub enum Error {
     /// An empty set had been passed when creating new prover.
     #[error("Set cannot be empty")]
     EmptySet,
+    /// Failed to serialize parameters, or verifying key.
+    #[error("Parameters or verifying key serialization failed {}", .0)]
+    Serialization(#[from] std::io::Error),
 }
 type Result<T> = std::result::Result<T, Error>;
 
+/// Parameters used to generate and verify the proof.
+/// Parameters are kept in their original form, but could be kept as bytes if ram will be a bigger
+/// issue than verification speed.
+/// This struct should be passed around as reference, since it is large and expensive to generate.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SetMembershipParams {
+    /// Parameters used to generate and verify the proof.
+    #[serde(with = "halo2_params")]
+    inner: Params<EqAffine>,
+}
+
+/// Custom Serde serialization and deserialization for Halo2 parameters.
+pub mod halo2_params {
+    use serde::{Deserializer, Serializer};
+
+    use super::*;
+
+    /// Serializing Halo2 parameters to bytes and then passing it to Serde serializer.
+    pub fn serialize<S>(
+        inner: &Params<EqAffine>,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut byte_buf = Vec::new();
+        inner.write(&mut byte_buf).map_err(|e| {
+            serde::ser::Error::custom(format!("Writing Halo2 params to bytes failed: {e}"))
+        })?;
+        serializer.serialize_bytes(&byte_buf)
+    }
+
+    /// Deserializing Halo2 parameters from serde dedserializer to bytes and reading it to actual params.
+    pub fn deserialize<'de, D>(deserializer: D) -> std::result::Result<Params<EqAffine>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = Vec::<u8>::deserialize(deserializer).map_err(|e| {
+            serde::de::Error::custom(format!(
+                "Failed to deserialize into Halo2 params bytes from Serde obejct to bytes: {e}"
+            ))
+        })?;
+        Params::<EqAffine>::read(&mut std::io::Cursor::new(bytes)).map_err(|e| {
+            serde::de::Error::custom(format!(
+                "Failed to deserialize into Halo2 params from bytes: {e}"
+            ))
+        })
+    }
+}
+
+// TODO figure out if any of these functions will block.
+impl SetMembershipParams {
+    /// Creates a new instance of the parameters.
+    /// The value of k is hardcoded here to be 10, since that's what works with the underlying Halo2 circuit.
+    /// Theoretically this function should only be called once, the resulting struct stored
+    /// and passed around as reference, because the params are both expensive to generate and large.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Serialize the parameters to a writer as bytes.
+    pub fn write<W: std::io::Write>(&self, buf: &mut W) -> Result<()> {
+        self.inner.write(buf)?;
+
+        Ok(())
+    }
+
+    /// Deserialize the parameters from bytes from a reader.
+    pub fn read<R: std::io::Read>(buf: &mut R) -> Result<Self> {
+        let inner = Params::read(buf)?;
+        Ok(Self { inner })
+    }
+
+    /// Get the inner parameters.
+    pub fn get_inner(&self) -> &Params<EqAffine> {
+        &self.inner
+    }
+}
+
+impl Default for SetMembershipParams {
+    /// Default implementation for params with k = 10.
+    fn default() -> Self {
+        // The value of k is specific for the circuit, so it is hardcoded here.
+        let k = 10;
+        let inner = Params::new(k);
+        debug!("New Halo2 params created for set membership ZKP with k = {k}");
+
+        Self { inner }
+    }
+}
+
 /// All required info to prove that a given element is a member of the set.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetMembershipProof {
     /// Verification key used to verify the proof.
-    vk: VerifyingKey<EqAffine>,
-    /// Parameters used to generate and verify the proof.
-    params: Params<EqAffine>,
+    vk: Vec<u8>,
     /// The actual proof that the element is a member of the set in bytes.
     proof: Vec<u8>,
 }
@@ -50,6 +145,12 @@ pub struct SetMembershipProof {
 impl SetMembershipProof {
     /// Proves that the element at the given index is a member of the set.
     /// Merkle tree and set are passed by reference to avoid large memory usage
+    ///
+    /// # Note
+    ///
+    /// This function is blocking, so use .spawn_blocking() ir it's equivalent,
+    /// if you want to run it in an async context.
+    ///
     /// # Arguments
     ///
     /// - `index` - The index of the element in the set.
@@ -70,6 +171,7 @@ impl SetMembershipProof {
     /// use digital_voting::set_membership_zkp::poseidon_hasher::{self, Digest};
     /// use digital_voting::set_membership_zkp::set_membership::SetMembershipProof;
     /// use digital_voting::set_membership_zkp::merkle::MerkleTree;
+    /// use digital_voting::set_membership_zkp::set_membership::SetMembershipParams;
     ///
     /// let set = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     /// let merkle_tree = MerkleTree::<u64, [u8; 32]>::new(
@@ -77,12 +179,14 @@ impl SetMembershipProof {
     ///     Box::new(|a, b| poseidon_hasher::hash([Digest(*a), Digest(*b)]).0),
     ///     Box::new(|x| poseidon_hasher::hash([x.into(), x.into()]).0),
     /// ).unwrap();
-    /// let set_membership_proof = SetMembershipProof::new(5, &set, &merkle_tree).unwrap();
+    /// let params = SetMembershipParams::new();
+    /// let set_membership_proof = SetMembershipProof::new_blocking(5, &set, &merkle_tree, &params).unwrap();
     /// ```
-    pub fn new(
+    pub fn new_blocking(
         index: usize,
         set: &[u64],
         merkle_tree: &MerkleTree<u64, [u8; 32]>,
+        params: &SetMembershipParams,
     ) -> Result<SetMembershipProof> {
         let MerkleProof { proof, path, .. } = merkle_tree.get_proof(index)?;
 
@@ -104,14 +208,12 @@ impl SetMembershipProof {
 
         let circuit = SetMembershipCircuit::new(value, proof, path);
 
-        let params: Params<EqAffine> = Params::new(10);
-        let vk = keygen_vk(&params, &circuit)?;
-        let pk = keygen_pk(&params, vk.clone(), &circuit)?;
-
+        let vk = keygen_vk(params.get_inner(), &circuit)?;
+        let pk = keygen_pk(params.get_inner(), vk.clone(), &circuit)?;
         let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
 
         create_proof(
-            &params,
+            params.get_inner(),
             &pk,
             &[circuit],
             &[&[&[root], &[Fp::zero()]]],
@@ -120,11 +222,18 @@ impl SetMembershipProof {
         )?;
 
         let proof = transcript.finalize();
+        let vk = vk.to_bytes();
+        debug!("Set membership ZKP proof and VK created for item {index}");
 
-        Ok(SetMembershipProof { vk, params, proof })
+        Ok(SetMembershipProof { vk, proof })
     }
 
     /// Verifies the proof that the unknown element is a member of the set.
+    ///
+    /// # Note
+    ///
+    /// This function is blocking, so use .spawn_blocking() ir it's equivalent,
+    /// if you want to run it in an async context.
     ///
     /// # Arguments
     ///
@@ -144,6 +253,7 @@ impl SetMembershipProof {
     /// use digital_voting::set_membership_zkp::poseidon_hasher::{self, Digest};
     /// use digital_voting::set_membership_zkp::set_membership::SetMembershipProof;
     /// use digital_voting::set_membership_zkp::merkle::MerkleTree;
+    /// use digital_voting::set_membership_zkp::set_membership::SetMembershipParams;
     ///
     /// let set = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
     /// let merkle_tree = MerkleTree::<u64, [u8; 32]>::new(
@@ -151,21 +261,33 @@ impl SetMembershipProof {
     ///     Box::new(|a, b| poseidon_hasher::hash([Digest(*a), Digest(*b)]).0),
     ///     Box::new(|x| poseidon_hasher::hash([x.into(), x.into()]).0),
     /// ).unwrap();
-    /// let set_membership_proof = SetMembershipProof::new(5, &set, &merkle_tree).unwrap();
-    /// set_membership_proof.verify(merkle_tree.get_root()).unwrap();
+    /// let params = SetMembershipParams::new();
+    /// let set_membership_proof = SetMembershipProof::new_blocking(5, &set, &merkle_tree, &params).unwrap();
+    /// set_membership_proof.verify_blocking(merkle_tree.get_root(), &params).unwrap();
     /// ```
-    pub fn verify(&self, merkle_root: [u8; 32]) -> Result<()> {
+    pub fn verify_blocking(
+        &self,
+        merkle_root: [u8; 32],
+        params: &SetMembershipParams,
+    ) -> Result<()> {
+        let vk = VerifyingKey::<EqAffine>::from_bytes::<SetMembershipCircuit>(
+            &self.vk,
+            params.get_inner(),
+        )
+        .unwrap();
         let mut transcript =
             Blake2bRead::<_, _, Challenge255<_>>::init(std::io::Cursor::new(&self.proof));
         let root = Fp::from_raw(convert_u8_to_u64(merkle_root));
-
-        Ok(verify_proof(
-            &self.params,
-            &self.vk,
-            SingleVerifier::new(&self.params),
+        let res = Ok(verify_proof(
+            params.get_inner(),
+            &vk,
+            SingleVerifier::new(params.get_inner()),
             &[&[&[root], &[Fp::zero()]]],
             &mut transcript,
-        )?)
+        )?);
+        debug!("Set membership ZKP proof verified");
+
+        res
     }
 }
 
@@ -177,6 +299,7 @@ mod tests {
 
     #[test]
     fn test_prove_and_verify() {
+        let params = SetMembershipParams::new();
         let set = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
         let merkle_tree = MerkleTree::<u64, [u8; 32]>::new(
             &set,
@@ -186,7 +309,13 @@ mod tests {
         .unwrap();
         let merkle_root = merkle_tree.get_root();
 
-        let set_membership_proof = SetMembershipProof::new(5, &set, &merkle_tree).unwrap();
-        set_membership_proof.verify(merkle_root).unwrap();
+        let set_membership_proof =
+            SetMembershipProof::new_blocking(5, &set, &merkle_tree, &params).unwrap();
+        let mut test_buf = Vec::new();
+        params.write(&mut test_buf).unwrap();
+
+        set_membership_proof
+            .verify_blocking(merkle_root, &params)
+            .unwrap();
     }
 }


### PR DESCRIPTION
Couldn't get PSE's fork to work with the curves used for Poseidon hasher, so decided to fork Halo2 myself and update the PR which contains VerifyingKey serialization. So now I'm using my own fork of Halo2.

Besides that implemented Serde serialization for set membership and added some traces.