### PR TITLE
Add commitments

### DIFF
--- a/src/batcher/mod.rs
+++ b/src/batcher/mod.rs
@@ -2,7 +2,7 @@
 //! There's are two batcher crates on crates.io, but one of them is completely undocumented and thus sketchy
 //! and the other one seems way focused on batching complex operations rather than just data.
 
-use std::{marker::PhantomData, rc::Rc, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use chrono::Utc;
 use tokio::sync::{
@@ -32,8 +32,6 @@ pub struct Batcher<T> {
     rx: Receiver<T>,
     /// Buffer for the actual batched items.
     batch: Vec<T>,
-    /// Marker to make sure this struct is not Send.
-    _not_send_marker: NotSend,
 }
 
 impl<T> Batcher<T> {
@@ -68,9 +66,6 @@ impl<T> Batcher<T> {
                 batch_ready_notify,
                 rx,
                 batch: Vec::new(),
-                _not_send_marker: NotSend {
-                    _marker: PhantomData,
-                },
             },
             tx,
         )
@@ -170,13 +165,6 @@ impl<T> Batcher<T> {
         // Not sure how fast this is due to extra allocations.
         self.batch.drain(0..batch_size).collect()
     }
-}
-
-/// Marker to make sure this struct is not Send.
-#[allow(dead_code)]
-struct NotSend {
-    /// Including a PhantomData<Rc<()>> makes this struct not Send
-    _marker: PhantomData<Rc<()>>,
 }
 
 #[cfg(test)]

--- a/src/commitment/commitment_scheme.rs
+++ b/src/commitment/commitment_scheme.rs
@@ -1,0 +1,65 @@
+//! Module to construct, use and track commitment schemes.
+
+use serde::{Deserialize, Serialize};
+
+/// The actual commitment value wrapped in a struct for convenience and with Serde implementations.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Commitment(Vec<u8>);
+
+/// A type alias for cleaning up boiler plate code regarding the combine and hash (or commitment) function.
+type CommitmentFn<V, N, H> = Box<dyn Fn(&V, &N) -> H>;
+
+/// A commitment scheme based on a the provided commitment function.
+pub struct HashCommitmentScheme<V, N, H> {
+    commitment_fn: CommitmentFn<V, N, H>,
+}
+
+impl<V, N, H> HashCommitmentScheme<V, N, H>
+where
+    H: AsRef<[u8]>,
+{
+    /// Create a new commitment scheme from the provided commitment function.
+    pub fn new(hash_fn: CommitmentFn<V, N, H>) -> Self {
+        Self {
+            commitment_fn: hash_fn,
+        }
+    }
+
+    /// Commit to a value with a nonce.
+    pub fn commit(&self, value: &V, nonce: &N) -> Commitment {
+        let hash = (self.commitment_fn)(value, nonce);
+        Commitment(hash.as_ref().to_vec())
+    }
+
+    /// Verify a commitment.
+    pub fn verify(&self, value: &V, nonce: &N, commitment: &Commitment) -> bool {
+        let hash = (self.commitment_fn)(value, nonce);
+        hash.as_ref() == commitment.0.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO add tests with more different data types.
+
+    // A mock hasher to avoid having to link full blown hashers to this crate
+    // just for testing.
+    fn mock_hash(preimages: [u64; 2]) -> [u8; 8] {
+        (preimages[0] ^ preimages[1]).to_le_bytes()
+    }
+
+    #[test]
+    fn test_commitment() {
+        let hash_fn = Box::new(|value: &u64, nonce: &u64| mock_hash([*value, *nonce]));
+
+        let commitment_scheme = HashCommitmentScheme::new(hash_fn);
+
+        let value = 42;
+        let nonce = 0;
+        let commitment = commitment_scheme.commit(&value, &nonce);
+
+        assert!(commitment_scheme.verify(&value, &nonce, &commitment));
+    }
+}

--- a/src/commitment/mod.rs
+++ b/src/commitment/mod.rs
@@ -1,0 +1,5 @@
+//! Module for creating and verifying commitments.
+
+#![deny(missing_docs)]
+
+pub mod commitment_scheme;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 pub mod api;
 
 pub mod batcher;
+pub mod commitment;
 pub mod set_membership_zkp;
 mod utils;
 


### PR DESCRIPTION
Add code to help working with commitments including the serializable commitment itself and a commitment scheme struct to help using and tracking commitments. Also removed unnecessary marker data from the batcher.