### PR TITLE
Add precompiled deny and udeps to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,6 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
     - uses: actions/checkout@v2
@@ -65,7 +64,6 @@ jobs:
   formatting:
     name: Check formatting
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
     - uses: actions/checkout@v2
@@ -91,7 +89,6 @@ jobs:
   docrs:
     name: Build documentation
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
     - uses: actions/checkout@v2
@@ -116,7 +113,6 @@ jobs:
   lint:
     name: Run linters
     runs-on: ubuntu-latest
-    needs: build
 
     steps:
     - uses: actions/checkout@v2
@@ -139,28 +135,17 @@ jobs:
         command: clippy
         args: -- -D warnings
 
-  # TODO This job is taking way too long compared to the rest.
   dependencies:
     name: Check dependencies
     runs-on: ubuntu-latest
-    needs: build
+    # Building udeps and deny takes way too long, so using a prebuilt image.
+    container:
+      image: thrasherlt/digital-voting-rust-multi-toolchain:latest
 
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: default
-        toolchain: nightly
-        override: true
-
-    - name: Install cargo-deny
-      uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-deny
-        version: latest
-
+    # TODO not sure if two separate caches are required here:
     - name: cache
       uses: Swatinem/rust-cache@v2
       with:
@@ -168,12 +153,6 @@ jobs:
   
     - name: Check dependencies with cargo-deny
       run: cargo deny check
-
-    - name: Install cargo-udeps
-      uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-udeps
-        version: latest
 
     - name: cache
       uses: Swatinem/rust-cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Current version of rustc since the start of development:
+FROM rust:1.80.1
+
+RUN rustup default stable
+
+RUN rustup component add clippy
+RUN rustup component add rustfmt
+RUN rustup component add rust-docs
+RUN rustup component add rust-src
+
+# These components are not available through rustup and most github actions,
+# so precompiling them here:
+RUN cargo install cargo-deny
+RUN rustup toolchain install nightly
+RUN cargo +nightly install cargo-udeps
+
+LABEL version="1.0"
+LABEL description="Docker image with Rust nightly and linting tools preinstalled"
+
+ENTRYPOINT ["/bin/bash", "-c"]
+
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost/ || exit 1


### PR DESCRIPTION
Dependency check was taking way too long on Github Actions CI, because cargo-deny and cargo-udeps took ages to compile, so Added a docker image with these components prebuilt.