### PR TITLE
Add blind signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -298,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +339,24 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "constant_time_eq",
+]
+
+[[package]]
+name = "blind-rsa-signatures"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7a988a0de8f466ebc1b89f588aa8bdb28bd7e9a5f745da2b209e8f407d24ec"
+dependencies = [
+ "derive-new",
+ "derive_more",
+ "digest",
+ "hmac-sha256",
+ "hmac-sha512",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rsa",
+ "serde",
 ]
 
 [[package]]
@@ -422,6 +446,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -521,12 +551,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -539,7 +591,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -549,6 +601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -560,6 +613,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bincode",
+ "blind-rsa-signatures",
  "chrono",
  "halo2_gadgets",
  "halo2_proofs",
@@ -775,6 +829,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3688e69b38018fec1557254f64c8dc2cc8ec502890182f395dbb0aa997aa5735"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hmac-sha512"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ce1f4656bae589a3fab938f9f09bf58645b7ed01a2c5f8a3c238e01a4ef78a"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,6 +964,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "local-channel"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,10 +1074,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "serde",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1008,6 +1124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1076,6 +1193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,7 +1224,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1112,6 +1238,28 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1265,6 +1413,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+dependencies = [
+ "byteorder",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "serde",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,7 +1483,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1371,6 +1540,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1601,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1447,7 +1647,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1532,7 +1732,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1593,7 +1793,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1735,7 +1935,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -1757,7 +1957,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1964,8 +2164,14 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.72",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ tracing-actix-web = "0.7.11"
 # TODO keep in mind that halo2 paralellism may be an issue with Tokio
 halo2_proofs = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization" }
 halo2_gadgets = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization" }
+blind-rsa-signatures = "0.15.1"

--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
+    {  id = "RUSTSEC-2023-0071", reason = "The Marvin Attack only affects deterministicly padded RSA, while this crate uses PSS under the hood" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
@@ -229,7 +230,7 @@ unknown-git = "warn"
 # if not specified. If it is specified but empty, no registries are allowed.
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # List of URLs for allowed Git repositories
-allow-git = []
+allow-git = ["https://github.com/ThrasherLT/halo2.git?branch=ThrasherLT%2FVerifyingKey-serialization"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for

--- a/src/signature/blind_signature.rs
+++ b/src/signature/blind_signature.rs
@@ -1,0 +1,340 @@
+//! Blind signature for allowing the user to send his personal data to a signer, get a signature
+//! then use it as authentication in the blockchain without the signer being able to link the
+//! user with the signature.
+//! Also acts as a wrapper around the blind_rsa_signatures crate.
+
+use blind_rsa_signatures::{self, KeyPair, Options};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Errors that can occur when working with blind signatures.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Error from the underlying blind signature crate.
+    #[error("Blind signature failure {:?}", .0)]
+    BlindSignature(#[from] blind_rsa_signatures::Error),
+    /// Couldn't unblind the signature, because the unblinding secret was missing.
+    /// This should never happen, since the unblinding secret is set during the blinding process.
+    #[error("Unblinding secret is missing from unblinder")]
+    UnblindingSecretMissing,
+}
+type Result<T> = std::result::Result<T, Error>;
+
+// The following few structs are thin wrappers around the types from the blind signature crate.
+// So if in the future we needed to use a different crate, it wouldn't be tedious to swap out.
+
+/// A public key for blind signatures.
+/// Wrapper around the public key from the blind signature crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Publickey(pub Vec<u8>);
+
+impl TryFrom<Publickey> for blind_rsa_signatures::PublicKey {
+    type Error = Error;
+
+    fn try_from(pk: Publickey) -> Result<blind_rsa_signatures::PublicKey> {
+        blind_rsa_signatures::PublicKey::from_der(&pk.0).map_err(Error::from)
+    }
+}
+
+/// A blind signature.
+/// Wrapper around the blind signature from the blind signature crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlindSignature(pub Vec<u8>);
+
+impl From<blind_rsa_signatures::BlindSignature> for BlindSignature {
+    fn from(blind_signature: blind_rsa_signatures::BlindSignature) -> BlindSignature {
+        BlindSignature(blind_signature.0)
+    }
+}
+
+impl From<BlindSignature> for blind_rsa_signatures::BlindSignature {
+    fn from(blind_signature: BlindSignature) -> blind_rsa_signatures::BlindSignature {
+        blind_rsa_signatures::BlindSignature(blind_signature.0)
+    }
+}
+
+/// An unblinded signature.
+/// Wrapper around the unblinded signature from the blind signature crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Signature(pub Vec<u8>);
+
+impl From<Signature> for blind_rsa_signatures::Signature {
+    fn from(signature: Signature) -> blind_rsa_signatures::Signature {
+        blind_rsa_signatures::Signature(signature.0)
+    }
+}
+
+impl From<blind_rsa_signatures::Signature> for Signature {
+    fn from(signature: blind_rsa_signatures::Signature) -> Signature {
+        Signature(signature.0)
+    }
+}
+
+/// A blinded message.
+/// Wrapper around the blinded message from the blind signature crate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlindedMessage(pub Vec<u8>);
+
+impl From<blind_rsa_signatures::BlindedMessage> for BlindedMessage {
+    fn from(blinded_message: blind_rsa_signatures::BlindedMessage) -> BlindedMessage {
+        BlindedMessage(blinded_message.0)
+    }
+}
+
+/// The signer for blindly signing messages.
+pub struct BlindSigner {
+    /// The public key of the signer. This is sent to both the user and the verifier
+    pk: blind_rsa_signatures::PublicKey,
+    /// The secret key of the signer. This must never leave the server.
+    sk: blind_rsa_signatures::SecretKey,
+    /// Options for the blind signature scheme.
+    options: Options,
+}
+
+impl BlindSigner {
+    /// Create a new blind signer with it's own unique generated public key.
+    ///
+    /// # Returns
+    ///
+    /// A new blind signer.
+    ///
+    /// # Errors
+    ///
+    /// If the key generation fails, an error is returned.
+    pub fn new() -> Result<Self> {
+        // Since we're not supporting message randomizer, hardcoding default options for now.
+        let options = Options::default();
+        let rng = &mut rand::thread_rng();
+        let kp = KeyPair::generate(rng, 2048)?;
+        let (pk, sk) = (kp.pk, kp.sk);
+
+        Ok(Self { pk, sk, options })
+    }
+
+    /// Get the public key of the signer in DER format.
+    ///
+    /// # Returns
+    ///
+    /// The public key of the signer in DER format.
+    ///
+    /// # Errors
+    ///
+    /// If the public key cannot be serialized to DER format, an error is returned.
+    pub fn get_public_key(&self) -> Result<Publickey> {
+        Ok(Publickey(self.pk.to_der()?))
+    }
+
+    /// Blindly sign a message.
+    ///
+    /// # Arguments
+    ///
+    /// * `blinded_msg` - The blinded message to sign.
+    ///
+    /// # Returns
+    ///
+    /// The blind signature.
+    ///
+    /// # Errors
+    ///
+    /// If the signing fails, an error is returned.
+    pub fn bling_sign(&self, blinded_msg: BlindedMessage) -> Result<BlindSignature> {
+        let rng = &mut rand::thread_rng();
+        let blind_sig = self.sk.blind_sign(rng, &blinded_msg.0, &self.options)?;
+
+        Ok(blind_sig.into())
+    }
+}
+
+/// The verifier for verifying blind signatures.
+pub struct Verifier {
+    /// The public key received from the signer.
+    pk: blind_rsa_signatures::PublicKey,
+    /// Options for the blind signature scheme. Must match the options used by the signer and user.
+    options: Options,
+}
+
+impl Verifier {
+    /// Create a new verifier with the public key of the signer.
+    ///
+    /// # Arguments
+    ///
+    /// * `pk` - The public key of the signer.
+    ///
+    /// # Returns
+    ///
+    /// A new verifier.
+    ///
+    /// # Errors
+    ///
+    /// If the public key is invalid, an error is returned.
+    pub fn new(pk: Publickey) -> Result<Self> {
+        // Since we're not supporting message randomizer, hardcoding default options for now.
+        let options = Options::default();
+
+        Ok(Self {
+            pk: pk.try_into()?,
+            options,
+        })
+    }
+
+    /// Verify a signature.
+    ///
+    /// # Arguments
+    ///
+    /// * `signature` - The signature to verify.
+    ///
+    /// # Returns
+    ///
+    /// If the signature is valid, `Ok(())` is returned.
+    /// If the signature is invalid, an error is returned.
+    pub fn verify_signature(&self, signature: Signature, msg: &[u8]) -> Result<()> {
+        let sig = blind_rsa_signatures::Signature::from(signature);
+        sig.verify(&self.pk, None, msg, &self.options)?;
+
+        Ok(())
+    }
+}
+
+/// The blinder for blinding messages before sending them to the signer.
+pub struct Blinder {
+    /// The public key received from the signer.
+    pk: blind_rsa_signatures::PublicKey,
+    /// Options for the blind signature scheme. Must match the options used by the signer and verifier.
+    options: Options,
+}
+
+impl Blinder {
+    /// Create a new blinder with the public key of the signer.
+    ///
+    /// # Arguments
+    ///
+    /// * `pk` - The public key of the signer.
+    ///
+    /// # Returns
+    ///
+    /// A new blinder.
+    ///
+    /// # Errors
+    ///
+    /// If the public key is invalid, an error is returned.
+    pub fn new(pk: Publickey) -> Result<Self> {
+        // Since we're not supporting message randomizer, hardcoding default options for now.
+        let options = Options::default();
+
+        Ok(Self {
+            pk: pk.try_into()?,
+            options,
+        })
+    }
+
+    /// Blind a message.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - The message to blind.
+    ///
+    /// # Returns
+    ///
+    /// The blinded message and the unblinder.
+    ///
+    /// # Errors
+    ///
+    /// If the blinding fails, an error is returned.
+    pub fn blind(&self, msg: &[u8]) -> Result<(BlindedMessage, Unblinder)> {
+        let rng = &mut rand::thread_rng();
+        let blinding_result = self.pk.blind(rng, msg, false, &self.options)?;
+
+        let unblinder = Unblinder {
+            pk: self.pk.clone(),
+            options: self.options.clone(),
+            unblinding_secret: blinding_result.secret,
+        };
+
+        Ok((blinding_result.blind_msg.into(), unblinder))
+    }
+}
+
+/// Struct used for unblinding a signature with the information gathered during
+/// the blinding process.
+pub struct Unblinder {
+    /// The public key received from the signer.
+    pk: blind_rsa_signatures::PublicKey,
+    /// Options for the blind signature scheme. Must match the options used by the signer and verifier.
+    options: Options,
+    /// The unblinding secret used to unblind the signature. This must never leave the user.
+    unblinding_secret: blind_rsa_signatures::Secret,
+}
+
+impl Unblinder {
+    /// Unblind a signature.
+    ///
+    /// # Arguments
+    ///
+    /// * `blind_signature` - The blind signature to unblind.
+    /// * `msg` - The original secret message before it was blinded.
+    ///
+    /// # Returns
+    ///
+    /// The unblinded signature.
+    ///
+    /// # Errors
+    ///
+    /// If the unblinding secret is missing, an error is returned.
+    /// If the unblinding fails, an error is returned.
+    pub fn unblind_signature(
+        &self,
+        blind_signature: BlindSignature,
+        msg: &[u8],
+    ) -> Result<Signature> {
+        if self.unblinding_secret.0.is_empty() {
+            return Err(Error::UnblindingSecretMissing);
+        }
+
+        let signature = self.pk.finalize(
+            &blind_signature.into(),
+            &self.unblinding_secret,
+            None,
+            msg,
+            &self.options,
+        )?;
+
+        Ok(signature.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blind_signature() {
+        // Signer:
+        let blind_signer = BlindSigner::new().unwrap();
+
+        // User:
+        let msg = b"secret_message";
+        let blinder = Blinder::new(blind_signer.get_public_key().unwrap()).unwrap();
+        let (blind_msg, unblinder) = blinder.blind(msg).unwrap();
+        assert_ne!(msg, blind_msg.0.as_slice());
+
+        // Signer:
+        let blind_signature = blind_signer.bling_sign(blind_msg.clone()).unwrap();
+
+        // User:
+        let signature = unblinder
+            .unblind_signature(blind_signature.clone(), msg)
+            .unwrap();
+        assert_ne!(blind_signature.0, signature.0);
+
+        // Verifier:
+        let verifier = Verifier::new(blind_signer.get_public_key().unwrap()).unwrap();
+        verifier.verify_signature(signature.clone(), msg).unwrap();
+        // Asserting that the blind signature can't be used to verify the original message.
+        // Since then the signer can link the blind signature to the original message.
+        assert!(verifier
+            .verify_signature(Signature(blind_signature.0), msg)
+            .is_err());
+        // Same for the blind message and the unblinded signature
+        assert!(verifier.verify_signature(signature, &blind_msg.0).is_err());
+    }
+}

--- a/src/signature/blind_signature.rs
+++ b/src/signature/blind_signature.rs
@@ -3,6 +3,12 @@
 //! user with the signature.
 //! Also acts as a wrapper around the blind_rsa_signatures crate.
 
+// TODO blind_rsa_signatures uses the rsa crate which is vulnerable to the Marvin attack, but
+// the blind_rsa_signatures crate uses pss padding, so in theory the vulnerability should be mitigated,
+// but proper tests should still be done.
+// Also the blind_rsa_signatures crate has a message_randomizer feature which does not seem useful
+// but should still be investigated if not using it opens us up to vulnerabilities.
+
 use blind_rsa_signatures::{self, KeyPair, Options};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/src/signature/mod.rs
+++ b/src/signature/mod.rs
@@ -2,4 +2,5 @@
 
 #![deny(missing_docs)]
 
+pub mod blind_signature;
 pub mod digital_signature;


### PR DESCRIPTION
On the blockchain the blind signature will act as a way to verify that the user is eligible to vote. The election authority will verify the user's personal data and blindly sign the user's blinded message which will be the public key of the digital signature that the user will be using on the blockchain.