### PR TITLE
Add WASM CI tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -190,3 +190,21 @@ jobs:
 
     - name: Check unused dependencies with cargo-udeps
       run: cargo +nightly udeps --workspace --all-targets
+
+  wasm-test:
+    name: Test on WASM
+    runs-on: ubuntu-latest
+    # Using custom container to avoid waiting for wasm-pack and chromium driver to be installed
+    container:
+      image: thrasherlt/digital-voting-rust-multi-toolchain:latest
+
+    steps:
+      - uses: actions/checkout@v2
+  
+      - name: cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm-cargo-test-${{ hashFiles('**/Cargo.lock') }}    
+    
+      - name: Run tests on WASM
+        run: wasm-pack test --chrome --headless subcrates/crypto/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,25 +520,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +543,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tracing",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -638,12 +630,6 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -749,8 +735,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1019,7 +1007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
- "rayon",
 ]
 
 [[package]]
@@ -1033,6 +1020,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minicov"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71e683cd655513b99affab7d317deb690528255a0d5f717f1024093c12b169"
+dependencies = [
+ "cc",
+ "walkdir",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1344,26 +1341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1440,21 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -1919,6 +1911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +1953,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +1994,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68497a05fb21143a08a7d24fc81763384a3072ee43c44e86aad1744d6adef9d9"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "minicov",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8220be1fa9e4c889b30fd207d4906657e7e90b12e0e6b0c8b8d8709f5de021"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2044,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN rustup toolchain install nightly
 RUN cargo +nightly install cargo-udeps
 RUN cargo install wasm-pack
 RUN apt update
-RUN apt install -y chromium-driver
+RUN apt install -y chromium-driver clang
 
 LABEL version="1.0"
 LABEL description="Docker image with Rust nightly and linting tools preinstalled"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN rustup component add rust-src
 RUN cargo install cargo-deny
 RUN rustup toolchain install nightly
 RUN cargo +nightly install cargo-udeps
+RUN cargo install wasm-pack
+RUN apt update
+RUN apt install -y chromium-driver
 
 LABEL version="1.0"
 LABEL description="Docker image with Rust nightly and linting tools preinstalled"

--- a/subcrates/crypto/Cargo.toml
+++ b/subcrates/crypto/Cargo.toml
@@ -9,17 +9,22 @@ publish = false
 license = "Apache-2.0"
 repository = "https://github.com/your/repo"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 rand = "0.8.5"
 # TODO keep in mind that halo2 paralellism may be an issue with Tokio
-halo2_proofs = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization" }
+halo2_proofs = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization", default-features = false, features = ["batch"] }
 halo2_gadgets = { git = "https://github.com/ThrasherLT/halo2.git", branch = "ThrasherLT/VerifyingKey-serialization" }
 blind-rsa-signatures = "0.15.1"
 
 # wasm-bindgen = "0.2.93"
 
-ring.workspace = true
+ring = { workspace = true, features = ["wasm32_unknown_unknown_js"] }
 tracing.workspace = true
 serde.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.43"

--- a/subcrates/crypto/src/commitment/commitment_scheme.rs
+++ b/subcrates/crypto/src/commitment/commitment_scheme.rs
@@ -58,6 +58,8 @@ where
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     // TODO add tests with more different data types.
 
     // A mock hasher to avoid having to link full blown hashers to this crate
@@ -66,6 +68,7 @@ mod tests {
         (preimages[0] ^ preimages[1]).to_le_bytes()
     }
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_commitment() {
         let hash_fn = Box::new(|value: &u64, nonce: &u64| mock_hash([*value, *nonce]));

--- a/subcrates/crypto/src/lib.rs
+++ b/subcrates/crypto/src/lib.rs
@@ -2,3 +2,10 @@ pub mod commitment;
 pub mod set_membership_zkp;
 pub mod signature;
 mod utils;
+
+// Configuration for wasm-bindgen-test to run tests in browser.
+#[cfg(test)]
+mod tests {
+    #![cfg(target_arch = "wasm32")]
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+}

--- a/subcrates/crypto/src/set_membership_zkp/merkle.rs
+++ b/subcrates/crypto/src/set_membership_zkp/merkle.rs
@@ -302,6 +302,8 @@ where
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     // TODO add tests with more different data types.
 
     // A mock hasher to avoid having to link full blown hashers to this crate
@@ -310,6 +312,7 @@ mod tests {
         preimages[0] ^ preimages[1]
     }
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_merkle_tree_empty() {
         let leaves: Vec<u64> = vec![];
@@ -321,6 +324,7 @@ mod tests {
         assert!(tree.is_err());
     }
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_merkle_tree_proof_out_of_bounds() {
         let leaves = vec![1u64, 2u64, 3u64];
@@ -333,6 +337,7 @@ mod tests {
         assert!(tree.get_proof(leaves.len()).is_err());
     }
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_merkle_tree() {
         let leaves = vec![1u64, 2u64, 3u64];

--- a/subcrates/crypto/src/set_membership_zkp/poseidon_hasher.rs
+++ b/subcrates/crypto/src/set_membership_zkp/poseidon_hasher.rs
@@ -115,8 +115,8 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     // TODO, need to find out test values and make sure there aren't any bugs in the poseidon hash or the implementation around it.
-    #[ignore]
     #[wasm_bindgen_test]
+    #[ignore]
     #[test]
     fn test_poseidon_hasher_test_values() {
         // TODO currently these values are wrong, need to find the correct ones.

--- a/subcrates/crypto/src/set_membership_zkp/poseidon_hasher.rs
+++ b/subcrates/crypto/src/set_membership_zkp/poseidon_hasher.rs
@@ -112,10 +112,10 @@ pub fn hash(input: [Digest; 2]) -> Digest {
 mod tests {
     use super::*;
 
-    use wasm_bindgen_test::wasm_bindgen_test;
+    // use wasm_bindgen_test::wasm_bindgen_test;
 
     // TODO, need to find out test values and make sure there aren't any bugs in the poseidon hash or the implementation around it.
-    #[wasm_bindgen_test]
+    // #[wasm_bindgen_test]
     #[ignore]
     #[test]
     fn test_poseidon_hasher_test_values() {

--- a/subcrates/crypto/src/set_membership_zkp/poseidon_hasher.rs
+++ b/subcrates/crypto/src/set_membership_zkp/poseidon_hasher.rs
@@ -112,8 +112,11 @@ pub fn hash(input: [Digest; 2]) -> Digest {
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     // TODO, need to find out test values and make sure there aren't any bugs in the poseidon hash or the implementation around it.
     #[ignore]
+    #[wasm_bindgen_test]
     #[test]
     fn test_poseidon_hasher_test_values() {
         // TODO currently these values are wrong, need to find the correct ones.

--- a/subcrates/crypto/src/set_membership_zkp/set_membership.rs
+++ b/subcrates/crypto/src/set_membership_zkp/set_membership.rs
@@ -295,8 +295,11 @@ impl SetMembershipProof {
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::super::poseidon_hasher::{self, Digest};
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_prove_and_verify() {
         let params = SetMembershipParams::new();

--- a/subcrates/crypto/src/set_membership_zkp/set_membership_circuit.rs
+++ b/subcrates/crypto/src/set_membership_zkp/set_membership_circuit.rs
@@ -213,6 +213,8 @@ impl Circuit<Fp> for SetMembershipCircuit {
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::super::poseidon_hasher;
     use crate::utils::byte_ops::convert_u8_to_u64;
     use halo2_proofs::{circuit::Value, dev::MockProver, pasta::Fp};
@@ -231,6 +233,7 @@ mod tests {
         return digest.0;
     }
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_circuit_legit() {
         let leaf = 6u64;
@@ -256,6 +259,7 @@ mod tests {
         prover.assert_satisfied();
     }
 
+    #[wasm_bindgen_test]
     #[test]
     fn test_circuit_falsified() {
         let leaf = 6u64;

--- a/subcrates/crypto/src/signature/blind_signature.rs
+++ b/subcrates/crypto/src/signature/blind_signature.rs
@@ -312,6 +312,9 @@ impl Unblinder {
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
     #[test]
     fn test_blind_signature() {
         // Signer:

--- a/subcrates/crypto/src/signature/digital_signature.rs
+++ b/subcrates/crypto/src/signature/digital_signature.rs
@@ -90,6 +90,9 @@ impl Signature {
 mod tests {
     use super::*;
 
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[wasm_bindgen_test]
     #[test]
     fn test_signature() {
         let message = b"hello world";


### PR DESCRIPTION
Since some of the code will potentially be used from the browser and from wasm-time runtime, we need to run tests on WASM targer too.