### PR TITLE
Add LTO to release profile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
         key: ${{ matrix.target }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}  
         
     - name: Check project
-      run: cargo check --verbose --workspace --target ${{ matrix.target }}
+      run: cargo check --verbose --workspace --release --target ${{ matrix.target }}
 
 
   test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ bincode.workspace = true
 
 crypto.workspace = true
 protocol.workspace = true
+
+[profile.release]
+lto = true


### PR DESCRIPTION
LTO should produce smaller and faster binaries, but will need to be benchmarked in the future.