### PR TITLE
Add `SecretKey` to `digital_sign` for more convenint storage

### DIFF
--- a/subcrates/crypto/src/commitment.rs
+++ b/subcrates/crypto/src/commitment.rs
@@ -2,7 +2,6 @@
 
 // TODO add examples whe the API is more stable.
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Errors that can occur when working with commitment schemes.
@@ -17,11 +16,7 @@ pub enum Error {
 }
 type Result<T> = std::result::Result<T, Error>;
 
-/// The actual commitment value wrapped in a struct for convenience and with Serde implementations.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Commitment(Vec<u8>);
-
-crate::impl_key_display!(Commitment);
+crate::crypto_key!(Commitment, "Commitment value");
 
 /// A type alias for cleaning up boiler plate code regarding the combine and hash (or commitment) function.
 type CommitmentFn<V, N, H> = Box<dyn Fn(&V, &N) -> H>;

--- a/subcrates/crypto/src/signature/blind_sign.rs
+++ b/subcrates/crypto/src/signature/blind_sign.rs
@@ -10,12 +10,7 @@
 // but should still be investigated if not using it opens us up to vulnerabilities.
 
 use blind_rsa_signatures::{self, KeyPair, Options};
-use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::serde_as;
 use thiserror::Error;
-
-use crate::impl_key_display;
 
 /// Errors that can occur when working with blind signatures.
 #[derive(Error, Debug)]
@@ -36,11 +31,7 @@ type Result<T> = std::result::Result<T, Error>;
 // The following few structs are thin wrappers around the types from the blind signature crate.
 // So if in the future we needed to use a different crate, it wouldn't be tedious to swap out.
 
-/// A public key for blind signatures.
-/// Wrapper around the public key from the blind signature crate.
-#[serde_as]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
-pub struct PublicKey(#[serde_as(as = "Base64")] pub Vec<u8>);
+crate::crypto_key!(PublicKey, "Public key for blind signatures");
 
 impl TryFrom<PublicKey> for blind_rsa_signatures::PublicKey {
     type Error = Error;
@@ -50,12 +41,7 @@ impl TryFrom<PublicKey> for blind_rsa_signatures::PublicKey {
     }
 }
 
-impl_key_display!(PublicKey);
-
-/// A public key for blind signatures.
-/// Wrapper around the public key from the blind signature crate.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct SecretKey(pub Vec<u8>);
+crate::crypto_key!(SecretKey, "Public key for blind signatures");
 
 impl TryFrom<SecretKey> for blind_rsa_signatures::SecretKey {
     type Error = Error;
@@ -65,13 +51,7 @@ impl TryFrom<SecretKey> for blind_rsa_signatures::SecretKey {
     }
 }
 
-impl_key_display!(SecretKey);
-
-/// A blind signature.
-/// Wrapper around the blind signature from the blind signature crate.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlindSignature(#[serde_as(as = "Base64")] pub Vec<u8>);
+crate::crypto_key!(BlindSignature, "Blind signature");
 
 impl From<blind_rsa_signatures::BlindSignature> for BlindSignature {
     fn from(blind_signature: blind_rsa_signatures::BlindSignature) -> BlindSignature {
@@ -85,13 +65,7 @@ impl From<BlindSignature> for blind_rsa_signatures::BlindSignature {
     }
 }
 
-impl_key_display!(BlindSignature);
-
-/// An unblinded signature.
-/// Wrapper around the unblinded signature from the blind signature crate.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Signature(#[serde_as(as = "Base64")] pub Vec<u8>);
+crate::crypto_key!(Signature, "Unblinded signature");
 
 impl From<Signature> for blind_rsa_signatures::Signature {
     fn from(signature: Signature) -> blind_rsa_signatures::Signature {
@@ -105,21 +79,13 @@ impl From<blind_rsa_signatures::Signature> for Signature {
     }
 }
 
-impl_key_display!(Signature);
-
-/// A blinded message.
-/// Wrapper around the blinded message from the blind signature crate.
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlindedMessage(#[serde_as(as = "Base64")] pub Vec<u8>);
+crate::crypto_key!(BlindedMessage, "Blinded message");
 
 impl From<blind_rsa_signatures::BlindedMessage> for BlindedMessage {
     fn from(blinded_message: blind_rsa_signatures::BlindedMessage) -> BlindedMessage {
         BlindedMessage(blinded_message.0)
     }
 }
-
-impl_key_display!(BlindedMessage);
 
 /// The signer for blindly signing messages.
 #[derive(Debug, Clone)]

--- a/subcrates/crypto/src/utils.rs
+++ b/subcrates/crypto/src/utils.rs
@@ -3,7 +3,7 @@
 // Note: If you're getting errors in this macro, the error probably originates in one of the
 // places where this macro is being actually used.
 
-/// Usage: crate::crypto_key!(KeyTypeName, "Documentation description for the key"));
+/// Usage: `crate::crypto_key`!(`KeyTypeName`, "Documentation description for the key"));
 #[macro_export]
 macro_rules! crypto_key {
     ($t:ident, $doc:literal) => {

--- a/subcrates/crypto/src/utils.rs
+++ b/subcrates/crypto/src/utils.rs
@@ -1,11 +1,17 @@
 //! This module contains utility code used throughout the project.
 
-// TODO Maybe think of better naming.
 // Note: If you're getting errors in this macro, the error probably originates in one of the
 // places where this macro is being actually used.
+
+/// Usage: crate::crypto_key!(KeyTypeName, "Documentation description for the key"));
 #[macro_export]
-macro_rules! impl_key_display {
-    ($t:ty) => {
+macro_rules! crypto_key {
+    ($t:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[serde_with::serde_as]
+        #[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+        pub struct $t(#[serde_as(as = "serde_with::base64::Base64")] Vec<u8>);
+
         impl AsRef<[u8]> for $t {
             fn as_ref(&self) -> &[u8] {
                 &self.0

--- a/subcrates/protocol/src/vote.rs
+++ b/subcrates/protocol/src/vote.rs
@@ -172,10 +172,10 @@ mod tests {
         let digital_signer = digital_sign::Signer::new().unwrap();
         let msg = digital_signer.get_public_key();
         let blinder = blind_sign::Blinder::new(blind_signer.get_public_key().unwrap()).unwrap();
-        let (blind_msg, unblinder) = blinder.blind(&msg.0).unwrap();
+        let (blind_msg, unblinder) = blinder.blind(&msg).unwrap();
         let blind_signature = blind_signer.bling_sign(&blind_msg).unwrap();
         let access_token = unblinder
-            .unblind_signature(blind_signature.clone(), &msg.0)
+            .unblind_signature(blind_signature.clone(), &msg)
             .unwrap();
         let vote = Vote::new(&digital_signer, candidate, timestamp, access_token).unwrap();
 


### PR DESCRIPTION
Client side storage will probably be done in JSON and base64 format, so it's more convenient to have a `SecretKey` type and load the `Signer` from it. Also added more code to the key generation macro, to deduplicate even more code.