### PR TITLE
Add multi user support

### DIFF
--- a/subcrates/client/src/authentication.rs
+++ b/subcrates/client/src/authentication.rs
@@ -1,3 +1,5 @@
+//! File for the code required to authenticate the user.
+
 // TODO Docummentation
 // TODO local storage only works on pages that have the same origin
 
@@ -10,9 +12,7 @@ use leptos::{
 #[component]
 pub fn User() -> impl IntoView {
     view! {
-        <Show when=State::can_login fallback=|| ()>
-            <Login />
-        </Show>
+        <Login />
         <Register />
     }
 }

--- a/subcrates/client/src/main.rs
+++ b/subcrates/client/src/main.rs
@@ -9,6 +9,7 @@ use leptos::{
 };
 
 mod authentication;
+mod settings;
 mod state;
 mod storage;
 mod utils;
@@ -47,6 +48,9 @@ pub fn App() -> impl IntoView {
     view! {
         <Show when=move || status.with(|status| matches!(status, Status::LoggedOut)) fallback=|| ()>
             <authentication::User />
+        </Show>
+        <Show when=move || status.with(|status| { *status > Status::LoggedOut }) fallback=|| ()>
+            <settings::SettingsPanel />
         </Show>
         <Show when=move || status.with(|status| matches!(status, Status::LoggedIn)) fallback=|| ()>
             <validation::ValidateVoter />

--- a/subcrates/client/src/settings.rs
+++ b/subcrates/client/src/settings.rs
@@ -1,0 +1,63 @@
+//! File containing code which handles the user settings for the browser extension.
+
+use crate::state::State;
+use leptos::{
+    component, create_signal, expect_context, view, IntoView, Show, SignalGet, SignalSet,
+};
+
+#[component]
+pub fn SettingsPanel() -> impl IntoView {
+    let (show_settings, set_show_settings) = create_signal(false);
+
+    view! {
+        <Show
+            when=move || show_settings.get()
+            fallback=move || {
+                view! {
+                    <button on:click=move |_| {
+                        set_show_settings.set(true);
+                    }>"Show settings"</button>
+                }
+            }
+        >
+            <button on:click=move |_| {
+                set_show_settings.set(false);
+            }>"Hide settings"</button>
+            <User />
+        </Show>
+    }
+}
+
+#[component]
+pub fn User() -> impl IntoView {
+    let (double_check, set_double_check) = create_signal(false);
+
+    view! {
+        <button on:click=move |_| {
+            let mut state = expect_context::<State>();
+            state.logout();
+        }>"Logout"</button>
+        <Show
+            when=move || double_check.get()
+            fallback=move || {
+                view! {
+                    <button on:click=move |_| {
+                        set_double_check.set(true);
+                    }>"Delete User"</button>
+                }
+            }
+        >
+            <button on:click=move |_| {
+                set_double_check.set(true);
+            }>"Delete User"</button>
+            <p>"Are you sure? This cannot be undone!"</p>
+            <button on:click=move |_| {
+                let mut state = expect_context::<State>();
+                state.delete_user();
+            }>"Yes, I'm sure"</button>
+            <button on:click=move |_| {
+                set_double_check.set(false);
+            }>"No, cancel"</button>
+        </Show>
+    }
+}

--- a/subcrates/client/src/state.rs
+++ b/subcrates/client/src/state.rs
@@ -246,7 +246,9 @@ impl State {
             })
             .ok_or(anyhow!("User is not logged in"))??;
         username.with(|username| {
-            if let Some(username) = username.as_ref() { storage.save(username) }
+            if let Some(username) = username.as_ref() {
+                storage.save(username)
+            }
         });
 
         Ok(())
@@ -280,10 +282,8 @@ mod tests {
         let mut state = State::new();
         assert!(matches!(state.get_status(), Status::LoggedOut));
 
-        assert!(!State::can_login());
         state.register_user(username, password).unwrap();
         assert!(matches!(state.get_status(), Status::LoggedIn));
-        assert!(State::can_login());
         let mut state = logout_login(state, username, password);
         assert!(matches!(state.get_status(), Status::LoggedIn));
 

--- a/subcrates/client/src/state.rs
+++ b/subcrates/client/src/state.rs
@@ -2,9 +2,11 @@
 //! Altho Leptos recomments using local signals for the logic, instead of a global state,
 //! the code, in that case, becomes unacceptably complicated.
 //! Besides that, this way the logic can be tested with simple unit tests at the end of this file.
+//! Reactive leptos slices were'nt used because they clone struct members on each read and that is an
+//! issue since some State struct members are keys which can be relatively large.
 
 use crate::storage::{KeyStore, Storage};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use crypto::{
     encryption::symmetric,
     signature::{blind_sign, digital_sign},
@@ -14,7 +16,6 @@ use protocol::{self, candidate_id::CandidateId, vote::Vote};
 
 // TODO Add proper documentation when the client's logic is more stable.
 // TODO Figure out how to display user friendly errors.
-// TODO Ensure that keys cannot be read from garbage after user had logged out.
 
 // Helper macro to clean up code around the `with!` Leptos macro:
 macro_rules! apply_read_only {
@@ -27,6 +28,7 @@ macro_rules! apply_read_only {
 
 /// Status of the client.
 /// Used to select which part of the UI to show to the user.
+#[derive(PartialEq, PartialOrd)]
 pub enum Status {
     LoggedOut,
     LoggedIn,
@@ -39,6 +41,7 @@ pub enum Status {
 /// The global state of the client.
 #[derive(Clone, Default)]
 pub struct State {
+    username: RwSignal<Option<String>>,
     encryption: RwSignal<Option<symmetric::Encryption>>,
     signer: RwSignal<Option<digital_sign::Signer>>,
     authority_key: RwSignal<Option<blind_sign::PublicKey>>,
@@ -54,7 +57,10 @@ impl State {
     }
 
     pub fn register_user(&mut self, username: &str, password: &str) -> Result<()> {
-        let encryption = symmetric::Encryption::new(username.as_bytes(), password.as_bytes())?;
+        if Storage::load(username).is_some() {
+            bail!("User already exists")
+        }
+        let encryption = symmetric::Encryption::new(password.as_bytes())?;
         let signer = digital_sign::Signer::new()?;
 
         KeyStore {
@@ -65,25 +71,18 @@ impl State {
             candidate: None,
         }
         .encrypt(&encryption)?
-        .save();
+        .save(username);
 
+        self.username.set(Some(username.to_owned()));
         self.encryption.set(Some(encryption));
         self.signer.set(Some(signer));
 
         Ok(())
     }
 
-    pub fn can_login() -> bool {
-        Storage::load().is_some()
-    }
-
     pub fn login_user(&mut self, username: &str, password: &str) -> Result<()> {
-        let storage = Storage::load().ok_or(anyhow!("User data is empty"))?;
-        let encryption = symmetric::Encryption::load(
-            username.as_bytes(),
-            password.as_bytes(),
-            storage.get_metadata(),
-        )?;
+        let storage = Storage::load(username).ok_or(anyhow!("User or password are incorrect"))?;
+        let encryption = symmetric::Encryption::load(password.as_bytes(), storage.get_metadata())?;
         let key_store = storage.decrypt(&encryption)?;
         let signer = if let Some(signer_sk) = key_store.signer_sk {
             Some(digital_sign::Signer::from_secret_key(signer_sk)?)
@@ -101,6 +100,7 @@ impl State {
             None
         };
 
+        self.username.set(Some(username.to_owned()));
         self.encryption.set(Some(encryption));
         self.signer.set(signer);
         self.authority_key.set(key_store.authority_key);
@@ -112,6 +112,28 @@ impl State {
         self.candidate.set(key_store.candidate);
 
         Ok(())
+    }
+
+    pub fn logout(&mut self) {
+        self.username.set(None);
+        self.encryption.set(None);
+        self.signer.set(None);
+        self.authority_key.set(None);
+        self.blinded_pk.set(None);
+        self.unblinder.set(None);
+        self.access_token.set(None);
+        self.candidate.set(None);
+    }
+
+    // TODO Ensure that keys cannot be read from garbage after user had logged out.
+    pub fn delete_user(&mut self) {
+        self.username.with(|username| {
+            username.as_ref().map(|username| {
+                Storage::delete(username);
+            })
+        });
+
+        self.logout();
     }
 
     pub fn get_status(&self) -> Status {
@@ -191,6 +213,7 @@ impl State {
 
     fn save(&self) -> Result<()> {
         let Self {
+            username,
             encryption,
             signer,
             authority_key,
@@ -215,14 +238,16 @@ impl State {
                 }
             }
         );
-        encryption
+        let storage = encryption
             .with(|encryption| {
                 encryption
                     .as_ref()
                     .map(|encryption| key_store.encrypt(encryption))
             })
-            .ok_or(anyhow!("User is not logged in"))??
-            .save();
+            .ok_or(anyhow!("User is not logged in"))??;
+        username.with(|username| {
+            if let Some(username) = username.as_ref() { storage.save(username) }
+        });
 
         Ok(())
     }

--- a/subcrates/client/src/storage.rs
+++ b/subcrates/client/src/storage.rs
@@ -44,16 +44,21 @@ impl Storage {
         &self.metadata
     }
 
-    pub fn load() -> Option<Self> {
-        let (storage, _, _) = use_local_storage::<Option<Storage>, JsonSerdeCodec>("signle-user");
+    pub fn load(username: &str) -> Option<Self> {
+        let (storage, _, _) = use_local_storage::<Option<Storage>, JsonSerdeCodec>(username);
 
         storage.get()
     }
 
-    pub fn save(self) {
-        let (_, set_storage, _) =
-            use_local_storage::<Option<Storage>, JsonSerdeCodec>("signle-user");
+    pub fn save(self, username: &str) {
+        let (_, set_storage, _) = use_local_storage::<Option<Storage>, JsonSerdeCodec>(username);
         set_storage.set(Some(self));
+    }
+
+    pub fn delete(username: &str) {
+        let (_, _, clear) = use_local_storage::<Option<Storage>, JsonSerdeCodec>(username);
+        // TODO Make sure data doesn't stay in leftover garbage:
+        clear();
     }
 
     pub fn decrypt(self, encryption: &symmetric::Encryption) -> Result<KeyStore> {

--- a/subcrates/client/src/utils.rs
+++ b/subcrates/client/src/utils.rs
@@ -1,3 +1,5 @@
+//! File containing common util code.
+
 use leptos::{component, view, IntoView, Show, Signal, SignalGet, SignalWith};
 use leptos_use::{use_clipboard, UseClipboardReturn};
 

--- a/subcrates/client/src/validation.rs
+++ b/subcrates/client/src/validation.rs
@@ -1,3 +1,5 @@
+//! This file contains the logic for validating the voter's right to vote.
+
 use std::str::FromStr;
 
 use crypto::signature::blind_sign;

--- a/subcrates/client/src/vote.rs
+++ b/subcrates/client/src/vote.rs
@@ -1,3 +1,5 @@
+//! This file contains the logic for casting an actual vote.
+
 use leptos::{
     component, create_node_ref, create_signal, event_target_value, expect_context, html, view,
     IntoView, NodeRef, Show, SignalGet, SignalSet,


### PR DESCRIPTION
Add code which allows support of multiple users. To achieve this, password salting had been simplified, but should still protect against rainbow attacks.