### PR TITLE
Fix time not implemented on this platform error on frontends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,12 +358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
-name = "anymap2"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -674,7 +668,7 @@ dependencies = [
  "console_error_panic_hook",
  "crypto",
  "futures",
- "gloo-timers 0.3.0",
+ "gloo-timers",
  "leptos",
  "leptos-use",
  "protocol",
@@ -683,8 +677,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.11",
  "tracing",
- "tracing-subscriber",
- "tracing-subscriber-wasm",
  "wasm-bindgen-test",
 ]
 
@@ -1192,13 +1184,11 @@ dependencies = [
  "console_error_panic_hook",
  "crypto",
  "futures",
- "gloo-timers 0.3.0",
+ "gloo-timers",
  "leptos",
  "leptos-use",
  "reqwasm",
  "tracing",
- "tracing-subscriber",
- "tracing-subscriber-wasm",
  "web-sys",
 ]
 
@@ -1334,86 +1324,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "gloo"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28999cda5ef6916ffd33fb4a7b87e1de633c47c0dc6d97905fee1cdaa142b94d"
-dependencies = [
- "gloo-console",
- "gloo-dialogs",
- "gloo-events",
- "gloo-file",
- "gloo-history",
- "gloo-net 0.3.1",
- "gloo-render",
- "gloo-storage",
- "gloo-timers 0.2.6",
- "gloo-utils 0.1.7",
- "gloo-worker",
-]
-
-[[package]]
-name = "gloo-console"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b7ce3c05debe147233596904981848862b068862e9ec3e34be446077190d3f"
-dependencies = [
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-dialogs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67062364ac72d27f08445a46cab428188e2e224ec9e37efdba48ae8c289002e6"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-events"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b107f8abed8105e4182de63845afcc7b69c098b7852a813ea7462a320992fc"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-file"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d5564e570a38b43d78bdc063374a0c3098c4f0d64005b12f9bbe87e869b6d7"
-dependencies = [
- "gloo-events",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-history"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85725d90bf0ed47063b3930ef28e863658a7905989e9929a8708aab74a1d5e7f"
-dependencies = [
- "gloo-events",
- "gloo-utils 0.1.7",
- "serde",
- "serde-wasm-bindgen",
- "serde_urlencoded",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "gloo-net"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,27 +1333,6 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils 0.1.7",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-net"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66b4e3c7d9ed8d315fd6b97c8b1f74a7c6ecbbc2320e65ae7ed38b7068cc620"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils 0.1.7",
- "http 0.2.12",
  "js-sys",
  "pin-project",
  "serde",
@@ -1473,41 +1362,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "gloo-render"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd9306aef67cfd4449823aadcd14e3958e0800aa2183955a309112a84ec7764"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-storage"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6ab60bf5dbfd6f0ed1f7843da31b41010515c745735c970e821945ca91e480"
-dependencies = [
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1545,23 +1399,6 @@ dependencies = [
  "serde",
  "serde_json",
  "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-worker"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13471584da78061a28306d1359dd0178d8d6fc1c7c80e5e35d27260346e0516a"
-dependencies = [
- "anymap2",
- "bincode",
- "gloo-console",
- "gloo-utils 0.1.7",
- "js-sys",
- "serde",
- "wasm-bindgen",
- "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -3015,17 +2852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,17 +3464,6 @@ dependencies = [
  "thread_local",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-subscriber-wasm"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79804e80980173c6c8e53d98508eb24a2dbc4ee17a3e8d2ca8e5bad6bf13a898"
-dependencies = [
- "gloo",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ tokio = { version = "1.43.0", features = ["full", "test-util"] }
 tracing-actix-web = "0.7.15"
 leptos = { version = "0.7.7", features = ["csr", "tracing"] }
 console_error_panic_hook = "0.1.7"
-tracing-subscriber-wasm = "0.1.0"
 reqwasm = "0.5.0"
 gloo-timers = { version = "0.3.0", features = ["futures"] }
 futures = "0.3.31"

--- a/subcrates/client/Cargo.toml
+++ b/subcrates/client/Cargo.toml
@@ -18,12 +18,10 @@ futures.workspace = true
 gloo-timers.workspace = true
 reqwasm.workspace = true
 console_error_panic_hook.workspace = true
-tracing-subscriber-wasm.workspace = true
 leptos.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 chrono.workspace = true
 serde_json.workspace = true
 

--- a/subcrates/client/src/main.rs
+++ b/subcrates/client/src/main.rs
@@ -26,12 +26,6 @@ mod tests {
 }
 
 fn main() {
-    tracing_subscriber::fmt()
-        .with_writer(
-            tracing_subscriber_wasm::MakeConsoleWriter::default()
-                .map_trace_level_to(tracing::Level::DEBUG),
-        )
-        .init();
     console_error_panic_hook::set_once();
 
     mount_to_body(App);

--- a/subcrates/mock_authority/frontend/Cargo.toml
+++ b/subcrates/mock_authority/frontend/Cargo.toml
@@ -14,9 +14,7 @@ web-sys = "0.3.77"
 
 leptos.workspace = true
 tracing.workspace = true
-tracing-subscriber.workspace = true
 console_error_panic_hook.workspace = true
-tracing-subscriber-wasm.workspace = true
 anyhow.workspace = true
 reqwasm.workspace = true
 gloo-timers.workspace = true

--- a/subcrates/mock_authority/frontend/src/main.rs
+++ b/subcrates/mock_authority/frontend/src/main.rs
@@ -27,12 +27,6 @@ fn App() -> impl IntoView {
 }
 
 fn main() {
-    tracing_subscriber::fmt()
-        .with_writer(
-            tracing_subscriber_wasm::MakeConsoleWriter::default()
-                .map_trace_level_to(tracing::Level::DEBUG),
-        )
-        .init();
     console_error_panic_hook::set_once();
 
     mount_to_body(App);


### PR DESCRIPTION
There was a wasm tracing subscriber error added for logging early on in the project, but it wasn't used and was was using `std::time::Instant::now()` under the hood which is not supported on WASM.