### PR TITLE
Add node selection to client

### DIFF
--- a/subcrates/client/src/fetch.rs
+++ b/subcrates/client/src/fetch.rs
@@ -2,7 +2,6 @@ use std::{pin::pin, time::Duration};
 
 use anyhow::{anyhow, bail, Result};
 use futures::future::{select, Either};
-use leptos::logging::log;
 use protocol::{config::ElectionConfig, vote::Vote};
 use reqwasm::http::Response;
 
@@ -20,7 +19,6 @@ pub async fn election_config(addr: String, timeout: Duration) -> Result<Election
 pub async fn submit_vote(addr: String, timeout: Duration, vote: Vote) -> Result<()> {
     let addr = format!("{addr}/vote");
     let vote = serde_json::to_string(&vote)?;
-    log!("{}", vote);
 
     let response = post(vote, &addr, timeout).await?;
     if response.status() != 200 {

--- a/subcrates/client/src/states/config.rs
+++ b/subcrates/client/src/states/config.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 
-use protocol::config::ElectionConfig;
+use crypto::signature::blind_sign;
+use protocol::config::{Candidate, ElectionConfig};
 
 use crate::{states::user::User, storage::Storage};
 
@@ -36,6 +37,18 @@ impl Config {
             .iter()
             .map(|auth| auth.addr.clone())
             .collect()
+    }
+
+    pub fn get_authority_pk(&self, index: usize) -> &blind_sign::PublicKey {
+        &self.election_config.authorities[index].authority_key
+    }
+
+    pub fn get_nodes(&self) -> &Vec<String> {
+        &self.election_config.nodes
+    }
+
+    pub fn get_candidates(&self) -> &Vec<Candidate> {
+        &self.election_config.candidates
     }
 
     pub fn delete(user: &User, blockchain: &str) {

--- a/subcrates/mock_authority/frontend/src/main.rs
+++ b/subcrates/mock_authority/frontend/src/main.rs
@@ -22,7 +22,7 @@ fn App() -> impl IntoView {
     view! {
         <h1>"Welcome to the mock election authority!"</h1>
         <p>"This is used only for testing and demonstration purposes."</p>
-        <BlindSigning/>
+        <BlindSigning />
     }
 }
 
@@ -129,12 +129,18 @@ pub fn Copyable(value: ReadSignal<Option<blind_sign::BlindSignature>>) -> impl I
     } = use_clipboard();
     view! {
         <Show when=move || value.with(Option::is_some) fallback=move || ()>
-            <input type="text" value=move || value.get().expect("Value to be some at this point").to_string() readonly />
+            <input
+                type="text"
+                value=move || value.get().expect("Value to be some at this point").to_string()
+                readonly
+            />
         </Show>
         <Show when=move || is_supported.get() && value.with(Option::is_some) fallback=|| ()>
             <button on:click={
                 let copy = copy.clone();
-                move |_| copy(&value.get().expect("Copyable value to be some after Show").to_string())
+                move |_| copy(
+                    &value.get().expect("Copyable value to be some after Show").to_string(),
+                )
             }>
                 <Show when=move || copied.get() fallback=move || "Copy">
                     "Copied!"


### PR DESCRIPTION
Since the client had been reworked to use an election ID instead of a node address, add node selection so that the vote can be sent to an actual URL. Also add check to verify access_tokens before storing them.